### PR TITLE
sloan_tree.coffee: Fix a tiny typo.

### DIFF
--- a/app/lib/sloan_tree.coffee
+++ b/app/lib/sloan_tree.coffee
@@ -2,7 +2,7 @@ DecisionTree = require 'lib/decision_tree'
 
 SloanTree = new DecisionTree 'sloan', ->
   @question 'Shape', 'Is the galaxy simply smooth and rounded, with no sign of a disk?', ->
-    @help "The aim here is to divide featureless galaxies from all the rest. If you can see any interesting features at all, click &quot;features or disk.&quot; Just occasionally you might see something that isn't a galaxy at all - the long streak of a satellite, for example, or a image swamped by light from a bright star. If this happens, just click &quot;star or artifact&quot;. Click to see larger images."
+    @help "The aim here is to divide featureless galaxies from all the rest. If you can see any interesting features at all, click &quot;features or disk.&quot; Just occasionally you might see something that isn't a galaxy at all - the long streak of a satellite, for example, or an image swamped by light from a bright star. If this happens, just click &quot;star or artifact&quot;. Click to see larger images."
     @answer 'Smooth', leadsTo: 'How rounded is it?', icon: 'smooth_round', examples: 1
     @answer 'Features or disk', leadsTo: 'Could this be a disk viewed edge-on?', icon: 'feature', examples: 3
     @answer 'Star or artifact', leadsTo: 'Would you like to discuss this object?', icon: 'star', examples: 2


### PR DESCRIPTION
The same mistake appears in a few more files.
