### PR TITLE
Examine (goods_full): Use a position search for "View on SkyServer"

### DIFF
--- a/app/views/examine/goods_full.eco
+++ b/app/views/examine/goods_full.eco
@@ -12,7 +12,7 @@
 <div class="row">
   <span class="key"></span>
   <span class="value">
-    <a target="_blank" href="http://cas.sdss.org/dr7/en/tools/quicklook/quickobj.asp?id=<%= @subject.metadata.sdss_id %>"><%- I18n.t 'examine.skyserver_link' %></a>
+    <a target="_blank" href="http://skyserver.sdss.org/dr8/en/tools/explore/obj.asp?ra=<%= @subject.coords[0] %>&dec=<%= @subject.coords[1] %>"><%- I18n.t 'examine.skyserver_link' %></a>
   </span>
 </div>
 <div class="row">


### PR DESCRIPTION
Instead of specifying an ID, which doesn't work for these subjects.
This should fix this issue:
https://github.com/zooniverse/Galaxy-Zoo/issues/194

I'm not entirely sure that this works, because I don't see the Right Ascension and Declination on this page at all when running it locally, I think because dev.zooniverse.org doesn't deliver them. But it looks like it should work with the real server.