### PR TITLE
fail gracefully if no subjects.

### DIFF
--- a/app/controllers/classify.coffee
+++ b/app/controllers/classify.coffee
@@ -87,7 +87,7 @@ class Classify extends Spine.Controller
     @render()
 
     setTimeout =>
-      if @subject.showInverted() then @toggleInverted()
+      if @subject?.showInverted() then @toggleInverted()
   
   answer: (ev) =>
     answer = $(ev.target).closest '.answer'

--- a/app/controllers/classify.coffee
+++ b/app/controllers/classify.coffee
@@ -82,7 +82,8 @@ class Classify extends Spine.Controller
 
   nextSubject: =>
     @subject = Subject.current
-    @classification = new Classification subject_id: @subject.id
+    if @subject?
+      @classification = new Classification subject_id: @subject.id
     @render()
 
     setTimeout =>


### PR DESCRIPTION
Ensure that we make it through to the render fallback "down for maintenance" message if @subject is not found when trying to advance to the next subject.
This fixes https://github.com/zooniverse/Galaxy-Zoo/issues/245.