### PR TITLE
URL for DECaLS image browser has changed.

### DIFF
--- a/app/views/examine/decals.eco
+++ b/app/views/examine/decals.eco
@@ -14,7 +14,7 @@
 <div class="row">
   <span class="key"></span>
   <span class="value">
-    <a target="_blank" href="http://imagine.legacysurvey.org/?ra=<%= @subject.coords[0] %>&dec=<%= @subject.coords[1] %>&zoom=14&layer=decals-dr1j"><%- I18n.t 'examine.legacyserver_link' %></a>
+    <a target="_blank" href="http://legacysurvey.org/viewer?ra=<%= @subject.coords[0] %>&dec=<%= @subject.coords[1] %>&zoom=14&layer=decals-dr2"><%- I18n.t 'examine.legacyserver_link' %></a>
   </span>
 </div>
 


### PR DESCRIPTION
URL changed on the link for the external site (according to @dstndstn); our link points directly at the DR2 layer (most recent at the time of this PR), but users can change the layer if desired once they go to the image browser. 