### PR TITLE
Switch underscore to hyphen for Chinese language nav.

### DIFF
--- a/app/views/navigation.eco
+++ b/app/views/navigation.eco
@@ -45,7 +45,7 @@
         <li><a data-lang-switch="fa" class="rtl">فارسی</a></li>
         <li><a data-lang-switch="he" class="rtl">עברית</a></li>
         <li><a data-lang-switch="uk">українська мова</a></li>
-        <li><a data-lang-switch="zh_tw">繁體中文</a></li>
+        <li><a data-lang-switch="zh-tw">繁體中文</a></li>
         <li><a data-lang-switch="zh_cn">简体中文</a></li>
       </ul>
     </li>


### PR DESCRIPTION
Follow-up to #254. Renaming the file worked, but users can't get there through the language switching tab. 

Eg:

https://www.galaxyzoo.org/?lang=zh_tw fails

but

https://www.galaxyzoo.org/?lang=zh-tw succeeds.