### PR TITLE
Copy files to zoo4.galaxyzoo.org when deploying

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -7,6 +7,11 @@ key_path = if destination && destination != 'quick'
 else
   "www.galaxyzoo.org"
 end
+archive_key_path = if destination && destination != 'quick'
+  nil
+else
+  "zoo4.galaxyzoo.org"
+end
 
 AWS.config access_key_id: ENV['AMAZON_ACCESS_KEY_ID'], secret_access_key: ENV['AMAZON_SECRET_ACCESS_KEY']
 s3 = AWS::S3.new
@@ -106,9 +111,11 @@ to_upload.each.with_index do |file, index|
   end
 
   bucket.objects["#{ key_path }/#{ file }"].write options
+  bucket.objects["#{ key_path }/#{ file }"].copy_to(bucket.objects["#{ archive_key_path }/#{ file }"]) if archive_key_path
 end
 
 bucket.objects["#{ key_path }/index.html"].write file: 'index.html', acl: :public_read, content_type: 'text/html', cache_control: 'no-cache, must-revalidate'
+bucket.objects["#{ key_path }/index.html"].copy_to(bucket.objects["#{ archive_key_path }/index.html"]) if archive_key_path
 
 Dir.chdir working_directory
 `rm -rf build`


### PR DESCRIPTION
So we have a permanent archive of the site after future versions are
launched.

Closes willettk/gzhubble#74