### PR TITLE
CSS fixes for some RTL language issues

### DIFF
--- a/css/locales.styl
+++ b/css/locales.styl
@@ -2,8 +2,13 @@ html:not([lang="en"])
   .advert
     display: none
 
+#zooniverse-top-bar-projects
+  white-space: nowrap
+
 // There has got to be a cleaner way to do this
 html[lang="fa"], .rtl
+  direction: rtl
+
   h1, h2, h3, h4, h5, h6, p, li, ul, span
     direction: rtl
 
@@ -12,6 +17,8 @@ html[lang="fa"], .rtl
     direction: ltr
 
 html[lang="he"], .rtl
+  direction: rtl
+
   h1, h2, h3, h4, h5, h6, p, li, ul, span
     direction: rtl
 


### PR DESCRIPTION
Fixes mix of LTR and RTL display in Hebrew and other RTL languages.
Prevents 'Our Projects' link from wrapping.