### PR TITLE
Layout fixes for classifier examples

### DIFF
--- a/css/dialog.styl
+++ b/css/dialog.styl
@@ -17,7 +17,7 @@
   .dialog
     position: fixed
     display: inline-block
-    top: 15%
+    top: 5%
     left: 25%
     max-width: 80%
     max-height: 600px

--- a/css/help.styl
+++ b/css/help.styl
@@ -5,6 +5,7 @@
     font-size: 12px
     font-weight: 400
     min-height: 200px
+    height: 800px
     text-align: left
     
     .heading, .sub-heading
@@ -46,7 +47,6 @@
             bottom: -17px
             line-height: 15px
             width: 300px
-            text-align: left
             font-weight: 700
         
         .example-images

--- a/css/locales.styl
+++ b/css/locales.styl
@@ -15,6 +15,13 @@ html[lang="fa"], .rtl
   #papers *,
   #team *
     direction: ltr
+  
+  .dialog
+    .help
+      text-align: right
+      
+      .label
+        text-align: right
 
 html[lang="he"], .rtl
   direction: rtl
@@ -44,6 +51,13 @@ html[lang="he"], .rtl
       width: 300px
       .description
         width: auto
+
+  .dialog
+    .help
+      text-align: right
+  
+      .label
+        text-align: right
 
 @media (max-width: 1385px)
   html[lang="he"]


### PR DESCRIPTION
Should fix bottom row of examples being cut off.
Fixes layout issues for RTL languages.

Towards #275 