### PR TITLE
Remove bad/duplicated setup advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,7 @@ Deploy CSS and JavaScript
 Full deploy (including images and other assets)
 `docker-compose run --service-ports galaxyzoo npm run deploy`
 
-### Getting Started
-
-```bash
-git clone https://github.com/zooniverse/Galaxy-Zoo.git
-cd Galaxy-Zoo
-npm install .
-
-./fits/build.rb
-./interactive/build.rb
-
-hem server
-open http://localhost:9294/
-```
-
-### Installation
+### Installation and Getting Started
 
 ```bash
 echo 'PATH="./node_modules/.bin:${PATH}"' >> ~/.bash_profile


### PR DESCRIPTION
The Installation and Getting Started sections were duplicates, though the Installation section didn't mention setting PATH and mentions some ruby scripts that don't seem to work anymore and don't seem to be necessary. This PATH thing confuses me every time I try to do this after a gap of a few months to forget it again. I never see it because it's mentioned after the first mention of "hem server".